### PR TITLE
Bower dependencies package name fix for jquery.bind-first

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "jquery": ">=1.5",
     "jquery.inputmask": ">=3.2.0",
-    "bind-first": ">=0.1.0"
+    "jquery.bind-first": ">=0.1.0"
   },
   "ignore": [
     "**/.*",


### PR DESCRIPTION
Wrong package name for Bower.
`bower install jquery.bind-first#v0.1.0 `
work well

```
bower install bind-first#v0.1.0
ENOTFOUND Package bind-first not found

```