### PR TITLE
jquery-inputmask is now inputmask

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,7 @@
   "homepage": "https://github.com/andr-04/inputmask-multi",
   "dependencies": {
     "jquery": ">=1.5",
-    "jquery.inputmask": ">=3.2.0"
+    "inputmask": ">=3.2.0"
   },
   "ignore": [
     "**/.*",


### PR DESCRIPTION
https://github.com/RobinHerbots/jquery.inputmask
This repo has been moved to https://github.com/RobinHerbots/Inputmask.

"jquery.inputmask" is now "inputmask"